### PR TITLE
feat(api): Implementa controllers e documentação com Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A arquitetura será baseada em microserviços com comunicação explícita, onde
 *   **(Bônus) Message Broker:** Para comunicação assíncrona, um broker como RabbitMQ ou Azure Service Bus poderia ser usado. Por exemplo, quando uma proposta é aprovada, PropostaService publica um evento `PropostaAprovadaEvent`, e ContratacaoService reage a esse evento. Para o teste, a comunicação síncrona via REST é suficiente e mais simples.
 
 ## 2. Estrutura dos Projetos (.NET)
-A organização dos projetos dentro da solution é crucial para refletir a arquitetura
+A organização dos projetos dentro da solution é crucial para refletir a arquitetura. Recomendo a seguinte estrutura para cada microserviço:
 
 ```
 Seguros.sln
@@ -110,7 +110,25 @@ Nesta etapa, o `ContratacaoService` foi inicializado e seus componentes principa
     *   **`Dockerfile`**: Define a imagem Docker para o `ContratacaoService.Api`.
 *   **`docker-compose.yml`**: Atualizado para incluir o serviço `contratacao-service` e seu banco de dados (`contratacao-db`), garantindo que ambos os microserviços possam ser orquestrados juntos.
 
-## 5. Comandos Essenciais
+## 5. Exposição e Documentação das APIs (Controllers e Swagger)
+
+Nesta etapa, os endpoints REST de ambos os serviços foram criados e documentados com Swagger.
+
+*   **`PropostasController.cs` (`PropostaService.Api`)**:
+    *   `POST /api/propostas`: Cria uma nova proposta.
+    *   `GET /api/propostas`: Lista todas as propostas.
+    *   `GET /api/propostas/{id}`: Busca uma proposta por ID.
+    *   `PATCH /api/propostas/{id}/status`: Altera o status de uma proposta (aceita "Aprovada" ou "Recusada").
+*   **`ContratacoesController.cs` (`ContratacaoService.Api`)**:
+    *   `POST /api/contratacoes`: Efetiva a contratação de uma proposta, recebendo o `propostaId` no corpo da requisição.
+*   **Documentação com Swagger**:
+    *   O pacote `Swashbuckle.AspNetCore` foi adicionado a ambos os projetos de API.
+    *   Os serviços foram configurados em `Program.cs` para gerar a documentação Swagger em ambiente de desenvolvimento.
+    *   As APIs podem ser exploradas e testadas através das seguintes URLs:
+        *   **PropostaService**: `http://localhost:5001/swagger`
+        *   **ContratacaoService**: `http://localhost:5002/swagger`
+
+## 6. Comandos Essenciais
 
 Para gerenciar o ambiente e o banco de dados:
 

--- a/Seguros/src/ContratacaoService.Api/ContratacaoService.Api.csproj
+++ b/Seguros/src/ContratacaoService.Api/ContratacaoService.Api.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Seguros/src/ContratacaoService.Api/Controllers/ContratacoesController.cs
+++ b/Seguros/src/ContratacaoService.Api/Controllers/ContratacoesController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+using ContratacaoService.Application.Services;
+using System;
+using System.Threading.Tasks;
+
+namespace ContratacaoService.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ContratacoesController : ControllerBase
+{
+    private readonly ContratacaoAppService _contratacaoAppService;
+
+    public ContratacoesController(ContratacaoAppService contratacaoAppService)
+    {
+        _contratacaoAppService = contratacaoAppService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> ContratarProposta([FromBody] Guid propostaId)
+    {
+        try
+        {
+            await _contratacaoAppService.ContratarAsync(propostaId);
+            return Ok();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return UnprocessableEntity(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+}

--- a/Seguros/src/PropostaService.Api/Controllers/PropostasController.cs
+++ b/Seguros/src/PropostaService.Api/Controllers/PropostasController.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Mvc;
+using PropostaService.Application.DTOs;
+using PropostaService.Application.Services;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PropostaService.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PropostasController : ControllerBase
+{
+    private readonly PropostaAppService _propostaAppService;
+
+    public PropostasController(PropostaAppService propostaAppService)
+    {
+        _propostaAppService = propostaAppService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CriarProposta([FromBody] PropostaInputModel inputModel)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var propostaViewModel = await _propostaAppService.CriarPropostaAsync(inputModel);
+        return CreatedAtAction(nameof(ObterPropostaPorId), new { id = propostaViewModel.Id }, propostaViewModel);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> ListarPropostas()
+    {
+        var propostas = await _propostaAppService.ListarTodasPropostasAsync();
+        return Ok(propostas);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> ObterPropostaPorId(Guid id)
+    {
+        var proposta = await _propostaAppService.ObterPropostaPorIdAsync(id);
+        if (proposta == null)
+        {
+            return NotFound();
+        }
+        return Ok(proposta);
+    }
+
+    [HttpPatch("{id}/status")]
+    public async Task<IActionResult> AlterarStatusProposta(Guid id, [FromBody] string status)
+    {
+        try
+        {
+            switch (status.ToLower())
+            {
+                case "aprovada":
+                    await _propostaAppService.AprovarPropostaAsync(id);
+                    break;
+                case "recusada":
+                    await _propostaAppService.RecusarPropostaAsync(id);
+                    break;
+                default:
+                    return BadRequest("Status inválido. Use 'Aprovada' ou 'Recusada'.");
+            }
+            return NoContent();
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return UnprocessableEntity(ex.Message);
+        }
+    }
+}

--- a/Seguros/src/PropostaService.Api/PropostaService.Api.csproj
+++ b/Seguros/src/PropostaService.Api/PropostaService.Api.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adiciona os controllers REST para expor as funcionalidades dos microserviços PropostaService e ContratacaoService. Integra o Swagger (Swashbuckle) para fornecer documentação interativa da API.

- Cria o 'PropostasController' com endpoints para o CRUD e alteração de status de propostas.
- Cria o 'ContratacoesController' com o endpoint para efetivar a contratação.
- Configura o Swagger em ambos os serviços para facilitar os testes e a exploração dos endpoints em ambiente de desenvolvimento.