### PR TITLE
test: Adiciona testes unitários para os serviços de aplicação

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,20 @@ Nesta etapa, os endpoints REST de ambos os serviços foram criados e documentado
         *   **PropostaService**: `http://localhost:5001/swagger`
         *   **ContratacaoService**: `http://localhost:5002/swagger`
 
-## 6. Comandos Essenciais
+## 6. Testes Unitários
+
+Foram criados testes unitários para os serviços de aplicação de ambos os microserviços, utilizando xUnit e Moq.
+
+*   **`PropostaAppServiceTests.cs`**:
+    *   Testa a criação de propostas.
+    *   Testa a obtenção de propostas por ID.
+    *   Testa a aprovação e recusa de propostas, incluindo casos de sucesso e falha (ex: tentar aprovar uma proposta já aprovada).
+*   **`ContratacaoAppServiceTests.cs`**:
+    *   Testa a contratação de uma proposta com status "Aprovada".
+    *   Testa a falha na contratação de uma proposta com status diferente de "Aprovada".
+    *   Testa o tratamento de erro quando a proposta não é encontrada.
+
+## 7. Comandos Essenciais
 
 Para gerenciar o ambiente e o banco de dados:
 

--- a/Seguros/tests/ContratacaoService.UnitTests/ContratacaoAppServiceTests.cs
+++ b/Seguros/tests/ContratacaoService.UnitTests/ContratacaoAppServiceTests.cs
@@ -1,0 +1,60 @@
+using Moq;
+using ContratacaoService.Application.Services;
+using ContratacaoService.Domain.Entities;
+using ContratacaoService.Domain.Repositories;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ContratacaoService.UnitTests;
+
+public class ContratacaoAppServiceTests
+{
+    private readonly Mock<IContratacaoRepository> _contratacaoRepositoryMock;
+    private readonly Mock<IPropostaServiceClient> _propostaServiceClientMock;
+    private readonly ContratacaoAppService _sut;
+
+    public ContratacaoAppServiceTests()
+    {
+        _contratacaoRepositoryMock = new Mock<IContratacaoRepository>();
+        _propostaServiceClientMock = new Mock<IPropostaServiceClient>();
+        _sut = new ContratacaoAppService(_contratacaoRepositoryMock.Object, _propostaServiceClientMock.Object);
+    }
+
+    [Fact]
+    public async Task ContratarAsync_Deve_AdicionarContratacao_Quando_PropostaAprovada()
+    {
+        // Arrange
+        var propostaId = Guid.NewGuid();
+        _propostaServiceClientMock.Setup(c => c.ObterStatusPropostaAsync(propostaId)).ReturnsAsync("Aprovada");
+        _contratacaoRepositoryMock.Setup(r => r.AdicionarAsync(It.IsAny<Contratacao>())).Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.ContratarAsync(propostaId);
+
+        // Assert
+        _contratacaoRepositoryMock.Verify(r => r.AdicionarAsync(It.Is<Contratacao>(c => c.PropostaId == propostaId)), Times.Once);
+    }
+
+    [Fact]
+    public async Task ContratarAsync_Deve_LancarExcecao_Quando_PropostaNaoAprovada()
+    {
+        // Arrange
+        var propostaId = Guid.NewGuid();
+        _propostaServiceClientMock.Setup(c => c.ObterStatusPropostaAsync(propostaId)).ReturnsAsync("Pendente");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.ContratarAsync(propostaId));
+    }
+
+    [Fact]
+    public async Task ContratarAsync_Deve_LancarExcecao_Quando_PropostaNaoEncontrada()
+    {
+        // Arrange
+        var propostaId = Guid.NewGuid();
+        _propostaServiceClientMock.Setup(c => c.ObterStatusPropostaAsync(propostaId)).ThrowsAsync(new Exception("Proposta não encontrada"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<Exception>(() => _sut.ContratarAsync(propostaId));
+    }
+}

--- a/Seguros/tests/PropostaService.UnitTests/PropostaAppServiceTests.cs
+++ b/Seguros/tests/PropostaService.UnitTests/PropostaAppServiceTests.cs
@@ -1,0 +1,115 @@
+using Moq;
+using PropostaService.Application.DTOs;
+using PropostaService.Application.Services;
+using PropostaService.Domain.Entities;
+using PropostaService.Domain.Enums;
+using PropostaService.Domain.Repositories;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PropostaService.UnitTests;
+
+public class PropostaAppServiceTests
+{
+    private readonly Mock<IPropostaRepository> _propostaRepositoryMock;
+    private readonly PropostaAppService _sut;
+
+    public PropostaAppServiceTests()
+    {
+        _propostaRepositoryMock = new Mock<IPropostaRepository>();
+        _sut = new PropostaAppService(_propostaRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task CriarPropostaAsync_Deve_AdicionarProposta_Quando_InputValido()
+    {
+        // Arrange
+        var inputModel = new PropostaInputModel("Cliente Teste", "12345678900", 30, 5000m);
+        _propostaRepositoryMock.Setup(r => r.AdicionarAsync(It.IsAny<Proposta>())).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _sut.CriarPropostaAsync(inputModel);
+
+        // Assert
+        _propostaRepositoryMock.Verify(r => r.AdicionarAsync(It.Is<Proposta>(p => p.NomeCliente == inputModel.NomeCliente)), Times.Once);
+        Assert.NotNull(result);
+        Assert.Equal(inputModel.NomeCliente, result.NomeCliente);
+    }
+
+    [Fact]
+    public async Task ObterPropostaPorIdAsync_Deve_RetornarProposta_Quando_PropostaExiste()
+    {
+        // Arrange
+        var propostaId = Guid.NewGuid();
+        var proposta = new Proposta("Cliente", "123", 25, 1000m);
+        _propostaRepositoryMock.Setup(r => r.ObterPorIdAsync(propostaId)).ReturnsAsync(proposta);
+
+        // Act
+        var result = await _sut.ObterPropostaPorIdAsync(propostaId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(proposta.Id, result.Id);
+    }
+
+    [Fact]
+    public async Task ObterPropostaPorIdAsync_Deve_RetornarNull_Quando_PropostaNaoExiste()
+    {
+        // Arrange
+        _propostaRepositoryMock.Setup(r => r.ObterPorIdAsync(It.IsAny<Guid>())).ReturnsAsync((Proposta?)null);
+
+        // Act
+        var result = await _sut.ObterPropostaPorIdAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task AprovarPropostaAsync_Deve_ChamarAtualizar_Quando_PropostaPendente()
+    {
+        // Arrange
+        var propostaId = Guid.NewGuid();
+        var proposta = new Proposta("Cliente", "123", 25, 1000m); // Status inicial é Pendente
+        _propostaRepositoryMock.Setup(r => r.ObterPorIdAsync(propostaId)).ReturnsAsync(proposta);
+        _propostaRepositoryMock.Setup(r => r.AtualizarAsync(It.IsAny<Proposta>())).Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.AprovarPropostaAsync(propostaId);
+
+        // Assert
+        _propostaRepositoryMock.Verify(r => r.AtualizarAsync(It.Is<Proposta>(p => p.Status == PropostaStatus.Aprovada)), Times.Once);
+    }
+
+    [Fact]
+    public async Task AprovarPropostaAsync_Deve_LancarExcecao_Quando_PropostaNaoPendente()
+    {
+        // Arrange
+        var propostaId = Guid.NewGuid();
+        var proposta = new Proposta("Cliente", "123", 25, 1000m);
+        proposta.Aprovar(); // Status agora é Aprovada
+        _propostaRepositoryMock.Setup(r => r.ObterPorIdAsync(propostaId)).ReturnsAsync(proposta);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.AprovarPropostaAsync(propostaId));
+    }
+    
+    [Fact]
+    public async Task RecusarPropostaAsync_Deve_ChamarAtualizar_Quando_PropostaPendente()
+    {
+        // Arrange
+        var propostaId = Guid.NewGuid();
+        var proposta = new Proposta("Cliente", "123", 25, 1000m); // Status inicial é Pendente
+        _propostaRepositoryMock.Setup(r => r.ObterPorIdAsync(propostaId)).ReturnsAsync(proposta);
+        _propostaRepositoryMock.Setup(r => r.AtualizarAsync(It.IsAny<Proposta>())).Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.RecusarPropostaAsync(propostaId);
+
+        // Assert
+        _propostaRepositoryMock.Verify(r => r.AtualizarAsync(It.Is<Proposta>(p => p.Status == PropostaStatus.Recusada)), Times.Once);
+    }
+}


### PR DESCRIPTION
Cria suítes de testes para PropostaAppService e ContratacaoAppService utilizando xUnit e Moq para garantir a corretude da lógica de negócio.

- PropostaAppServiceTests: Valida a criação, consulta e alteração de status de propostas, cobrindo cenários de sucesso e de falha (ex: transições de estado inválidas).
- ContratacaoAppServiceTests: Valida a lógica de contratação, incluindo a verificação do status da proposta via mock do IPropostaServiceClient e o tratamento de erros para propostas não encontradas ou com status inválido.